### PR TITLE
Enable use of SI unit abbreviations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,6 +131,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_yaml",
+ "si-unit-prefix",
  "strum",
  "strum_macros",
  "tabled",
@@ -1180,6 +1181,15 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "si-unit-prefix"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e70f7747805ca30c09b02c7503975d1d7864e43d5c88add41e9d461a6dd758c"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ log = "0.4.19"
 reqwest = { version = "0.11.18", features = ["blocking", "json"] }
 serde = { version = "1.0.164", features = ["derive"] }
 serde_yaml = "0.9.21"
+si-unit-prefix = "1.0.0"
 strum = { version = "0.25", features = ["derive"] }
 strum_macros = "0.25"
 tabled = "0.12.2"

--- a/README.md
+++ b/README.md
@@ -86,6 +86,13 @@ This will remove the commas and the unit and simply return `100000000`.
 If you want to get rid of the floating point and display rounded integers instead, use the `-i` flag:  
 `bitcoinvert -i 1234567 SAT USD`
 
+### Using SI suffixes for the amount
+For very big or small numbers, it's easier to use SI suffixes than adding a lot of zeros.  
+`bitcoinvert 1M SAT USD` => convert 1,000,000 SAT to USD  
+`bitcoinvert 1.23k SAT` => convert 1,230 SAT
+
+Find a list of possible suffixes [here](https://en.wikipedia.org/wiki/Metric_prefix#List_of_SI_prefixes).
+
 ### Multiple output currencies
 If you don't define the output currency, a table of various currencies will be displayed instead:  
 `bitcoinvert -i 1 BTC`

--- a/src/cli_input.rs
+++ b/src/cli_input.rs
@@ -12,7 +12,7 @@ use crate::Currency;
 #[clap(author, version, about, long_about = None)]
 pub struct Args {
     /// The amount of money to convert
-    pub amount: Option<f64>,
+    pub amount: Option<String>,
     /// The currency to convert from
     pub input_currency: Option<String>,
     /// The currency to convert to
@@ -79,9 +79,15 @@ impl CliInput {
         Args::parse().into()
     }
 
-    fn parse_amount(input: Option<f64>) -> f64 {
+    fn parse_amount(input: Option<String>) -> f64 {
         match input {
-            Some(amount) => amount,
+            Some(amount) => match amount.parse::<f64>() {
+                Ok(amount) => amount,
+                Err(_) => {
+                    eprintln!("\"{}\" is not a valid amount!", amount);
+                    process::exit(exitcode::USAGE);
+                }
+            },
             None => Defaults::get_default_amount(),
         }
     }

--- a/src/cli_input.rs
+++ b/src/cli_input.rs
@@ -1,5 +1,6 @@
 use clap::Parser;
 use colored::*;
+use si_unit_prefix::SiUnitPrefix;
 use std::error::Error;
 use std::num::ParseFloatError;
 use std::{fmt, process};
@@ -11,7 +12,7 @@ use crate::Currency;
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
 pub struct Args {
-    /// The amount of money to convert
+    /// The amount of money to convert (SI units are supported => 1k = 1,000, 1M = 1,000,000, etc.)
     pub amount: Option<String>,
     /// The currency to convert from
     pub input_currency: Option<String>,
@@ -81,13 +82,26 @@ impl CliInput {
 
     fn parse_amount(input: Option<String>) -> f64 {
         match input {
-            Some(amount) => match amount.parse::<f64>() {
-                Ok(amount) => amount,
-                Err(_) => {
-                    eprintln!("\"{}\" is not a valid amount!", amount);
-                    process::exit(exitcode::USAGE);
+            Some(mut amount) => {
+                // check whether last character is an SI unit
+                let mut multiplier = 1.0;
+                let last_char = amount.chars().last().unwrap();
+
+                if let Some(si_prefix) = SiUnitPrefix::parse_from_str(&last_char.to_string()) {
+                    multiplier = si_prefix.as_f64();
+
+                    // remove last character
+                    amount = amount[..amount.len() - 1].to_string();
                 }
-            },
+
+                match amount.parse::<f64>() {
+                    Ok(amount) => amount * multiplier,
+                    Err(_) => {
+                        eprintln!("\"{}\" is not a valid amount!", amount);
+                        process::exit(exitcode::USAGE);
+                    }
+                }
+            }
             None => Defaults::get_default_amount(),
         }
     }


### PR DESCRIPTION
Allow user input `1k` to be translated into `1,000` and `1M` into `1,000,000` and so on (check out [this list](https://en.wikipedia.org/wiki/Metric_prefix#List_of_SI_prefixes))

Fixes https://github.com/gcomte/bitcoinvert/issues/152