### PR TITLE
Allow thousand separators in amount input

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,6 +128,7 @@ dependencies = [
  "exitcode",
  "home-config",
  "log",
+ "regex",
  "reqwest",
  "serde",
  "serde_yaml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ env_logger = "0.10.0"
 exitcode = "1.1.2"
 home-config = { version = "0.6.0", features = ["yaml"] }
 log = "0.4.19"
+regex = "1.9.1"
 reqwest = { version = "0.11.18", features = ["blocking", "json"] }
 serde = { version = "1.0.168", features = ["derive"] }
 serde_yaml = "0.9.25"

--- a/src/cli_input.rs
+++ b/src/cli_input.rs
@@ -1,5 +1,6 @@
 use clap::Parser;
 use colored::*;
+use regex::Regex;
 use si_unit_prefix::SiUnitPrefix;
 use std::error::Error;
 use std::num::ParseFloatError;
@@ -8,6 +9,8 @@ use std::{fmt, process};
 use crate::currencies::Currencies;
 use crate::defaults::Defaults;
 use crate::Currency;
+
+const THOUSAND_SEPARATOR_PATTERN: &str = r",|\s|'";
 
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
@@ -94,7 +97,7 @@ impl CliInput {
                     amount = amount[..amount.len() - 1].to_string();
                 }
 
-                match amount.parse::<f64>() {
+                match Self::strip_thousand_separators(&amount).parse::<f64>() {
                     Ok(amount) => amount * multiplier,
                     Err(_) => {
                         eprintln!("\"{}\" is not a valid amount!", amount);
@@ -130,5 +133,10 @@ impl CliInput {
         }
 
         Defaults::get_default_output_currencies()
+    }
+
+    fn strip_thousand_separators(amount: &str) -> String {
+        let re = Regex::new(THOUSAND_SEPARATOR_PATTERN).unwrap();
+        re.replace_all(amount, "").to_string()
     }
 }

--- a/tests/int_tests.rs
+++ b/tests/int_tests.rs
@@ -77,6 +77,20 @@ fn test_amount_input_validation() {
     cmd.args(vec![&si_suffix_floating, "SAT", "BTC"])
         .assert()
         .stdout("0.0001234 BTC\n");
+
+    // Allow using floating point numbers with thousand separators
+    let mut cmd = Command::cargo_bin("bitcoinvert").unwrap();
+    let thousand_separated_float = "1'000 000,000.25";
+    cmd.args(vec![&thousand_separated_float, "SAT", "BTC"])
+        .assert()
+        .stdout("10.0000000025 BTC\n");
+
+    // Print correct error message when only supplying thousand separators
+    let mut cmd = Command::cargo_bin("bitcoinvert").unwrap();
+    let thousand_separator = ", '";
+    cmd.args(vec![&thousand_separator, "SAT", "BTC"])
+        .assert()
+        .stderr(format!("\"{thousand_separator}\" is not a valid amount!\n"));
 }
 
 #[test]


### PR DESCRIPTION
Allows the user to input an amount with a thousand separator (`1,000.25` or `1 000.25`). 

Fixes #160 