### PR TITLE
Stop supporting Croatian Kuna

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,6 @@ unit | description
 `EUR` | Euro
 `GBP` | Pound sterling
 `HKD` | Hong Kong dollar
-`HRK` | Croatian kuna
 `HUF` | Hungarian forint
 `INR` | Indian rupee
 `ISK` | Icelandic króna

--- a/src/currency/fiat.rs
+++ b/src/currency/fiat.rs
@@ -27,7 +27,6 @@ pub enum Fiat {
     EUR,
     GBP,
     HKD,
-    HRK,
     HUF,
     INR,
     ISK,

--- a/src/fiat_rates/blockchain_info_consumer.rs
+++ b/src/fiat_rates/blockchain_info_consumer.rs
@@ -46,8 +46,6 @@ struct Currencies {
     gbp: Ticker,
     #[serde(rename(deserialize = "HKD"))]
     hkd: Ticker,
-    #[serde(rename(deserialize = "HRK"))]
-    hrk: Ticker,
     #[serde(rename(deserialize = "HUF"))]
     huf: Ticker,
     #[serde(rename(deserialize = "INR"))]
@@ -109,7 +107,6 @@ impl ExchangeRateApiConsumer for ApiConsumer {
         map.insert(Fiat::EUR, currencies.eur.last);
         map.insert(Fiat::GBP, currencies.gbp.last);
         map.insert(Fiat::HKD, currencies.hkd.last);
-        map.insert(Fiat::HRK, currencies.hrk.last);
         map.insert(Fiat::HUF, currencies.huf.last);
         map.insert(Fiat::INR, currencies.inr.last);
         map.insert(Fiat::ISK, currencies.isk.last);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Enhanced the README with clearer installation instructions for Linux and MacOS.
	- Updated the user manual with detailed command usage examples and clarified default behaviors.
	- Improved the configuration section with sample YAML format and location details.
	- Reformatted the supported currencies section for better readability.

- **Bug Fixes**
	- Removed the Croatian Kuna (HRK) from the available fiat currencies, ensuring consistency in the currency representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->