### PR TITLE
Update CI: replace archived actions, enforce clippy, pin linelint

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,11 +16,8 @@ jobs:
     name: Build and Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: rust-toolchain
-        uses: actions-rs/toolchain@v1.0.6
-        with:
-          toolchain: stable
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
       - name: Build
         run: cargo build --verbose
       - name: Run unit tests

--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Linelint
-        uses: fernandrone/linelint@0.4.0
+        uses: fernandrone/linelint@0.0.6
         id: linelint
   unused_dependencies:
     name: Look for unused dependencies

--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -13,11 +13,8 @@ jobs:
     name: Security audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: rust-toolchain
-        uses: actions-rs/toolchain@v1.0.6
-        with:
-          toolchain: stable
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
       - name: Install security audit
         run: cargo install cargo-audit
       - name: Run security audit
@@ -26,11 +23,9 @@ jobs:
     name: Check code formatting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: rust-toolchain
-        uses: actions-rs/toolchain@v1.0.6
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
           components: rustfmt
       - name: Check code formatting
         run: cargo fmt --check --all
@@ -38,33 +33,27 @@ jobs:
     name: Clippy check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: rust-toolchain
-        uses: actions-rs/toolchain@v1.0.6
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
           components: clippy
       - name: Clippy
-        run: cargo clippy --all-targets
+        run: cargo clippy --all-targets -- -D warnings
   linelint:
     name: Check that files end with line break
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Linelint
-        uses: fernandrone/linelint@master
+        uses: fernandrone/linelint@0.4.0
         id: linelint
   unused_dependencies:
     name: Look for unused dependencies
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: rust-toolchain
-        uses: actions-rs/toolchain@v1.0.6
-        with:
-          toolchain: nightly
-          override: true
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
       - name: Install unused dependency checker
         run: cargo install cargo-udeps
       - name: Run unused dependency checker

--- a/src/defaults.rs
+++ b/src/defaults.rs
@@ -54,7 +54,7 @@ impl Defaults {
             "Reading contents of file {} --> input amount: {}, input currency: {}, output currencies: [{}]",
             config.path().display(),
             defaults.amount,
-            defaults.input_currency.to_string(),
+            defaults.input_currency,
             defaults
                 .output_currencies
                 .iter()

--- a/tests/int_tests.rs
+++ b/tests/int_tests.rs
@@ -71,7 +71,7 @@ fn test_amount_input_validation() {
     let si_suffix = "1M";
     cmd.args(vec![&si_suffix, "SAT", "BTC"])
         .assert()
-        .stdout(format!("0.01 BTC\n"));
+        .stdout("0.01 BTC\n".to_string());
 
     // Allow using floating point numbers
     let mut cmd = cargo::cargo_bin_cmd!("bitcoinvert");


### PR DESCRIPTION
## Summary
- Replace archived `actions-rs/toolchain@v1.0.6` with `dtolnay/rust-toolchain`
- Update `actions/checkout` from v2/v3 to v4
- Add `-- -D warnings` to clippy so warnings fail the build
- Pin `fernandrone/linelint` to `@0.4.0` instead of `@master` for reproducibility