### PR TITLE
Pin cargo-udeps install in CI

### DIFF
--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -55,6 +55,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
       - name: Install unused dependency checker
-        run: cargo install cargo-udeps
+        run: cargo install cargo-udeps --version 0.1.61 --locked
       - name: Run unused dependency checker
         run: cargo +nightly udeps --all-targets


### PR DESCRIPTION
## Summary
- Pin cargo-udeps to 0.1.61 in the static analysis workflow
- Install it with --locked so CI uses the crate's tested dependency graph

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to use a pinned version of a build dependency management tool with locked dependencies, improving build reproducibility and consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gcomte/bitcoinvert/pull/520?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->